### PR TITLE
feat: add json support to test client

### DIFF
--- a/football_service/user/tests/test_user_api.py
+++ b/football_service/user/tests/test_user_api.py
@@ -35,7 +35,7 @@ def test_create_user_success(client: OpenAPIClient):
     }
 
     # when
-    response = client.post(url, payload)
+    response = client.post(url, json=payload)
 
     # then
     assert response.status_code == status.HTTP_201_CREATED

--- a/football_service/utils/test_utils/test_client.py
+++ b/football_service/utils/test_utils/test_client.py
@@ -1,6 +1,8 @@
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Callable
 from unittest.mock import MagicMock
 
+from django.core.handlers.wsgi import WSGIRequest
 from openapi_tester import SchemaTester
 from openapi_tester.clients import OpenAPIClient
 
@@ -20,6 +22,27 @@ class FootTestClient(OpenAPIClient):
     @openapi_validate.setter
     def openapi_validate(self, value: bool) -> None:
         self._openapi_validate = value
+
+    def json_support(function: Callable) -> Callable:
+        def wrapped(self, *args, **kwargs):
+            if "json" in kwargs:
+                kwargs["data"] = json.dumps(kwargs["json"])
+                kwargs["content_type"] = "application/json"
+            return function(self, *args, **kwargs)
+
+        return wrapped
+
+    @json_support
+    def post(self, *args, **kwargs) -> WSGIRequest:
+        return super().post(*args, **kwargs)
+
+    @json_support
+    def put(self, *args, **kwargs) -> WSGIRequest:
+        return super().put(*args, **kwargs)
+
+    @json_support
+    def patch(self, *args, **kwargs) -> WSGIRequest:
+        return super().patch(*args, **kwargs)
 
     def request(self, **kwargs) -> "Response":  # type: ignore[override]
         if self.openapi_validate:


### PR DESCRIPTION
Adding support for submitting a `json` payload with `application/json` content type to test client.
This is because by default, `data` is sent as multi-form data, and API will be exposed only with `application/json` documentation.